### PR TITLE
allow adding a 'danger ok' marker to exclude false positives from danger

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -21,10 +21,10 @@ end
 
 # Don't let testing shortcuts get into master by accident
 if Dir.exists?('spec')
-  fail("fdescribe left in tests") if `grep -r -e '\\bfdescribe\\b' spec/ `.length > 1
-  fail("fit left in tests") if `grep -r -e '\\bfit\\b' spec/ `.length > 1
-  fail("ap left in tests") if `grep -r -e '\\bap\\b' spec/ `.length > 1
-  fail("puts left in tests") if `grep -r -e '\\bputs\\b' spec/ `.length > 1
+  fail("fdescribe left in tests") if `grep -r -e '\\bfdescribe\\b' spec/ |grep -v 'danger ok' `.length > 1
+  fail("fit left in tests") if `grep -r -e '\\bfit\\b' spec/ | grep -v 'danger ok' `.length > 1
+  fail("ap left in tests") if `grep -r -e '\\bap\\b' spec/ | grep -v 'danger ok' `.length > 1
+  fail("puts left in tests") if `grep -r -e '\\bputs\\b' spec/ | grep -v 'danger ok' `.length > 1
 end
 
 if git.commits.any? {|c| c.message =~ /(fixup|squash)!/ }

--- a/lib/netsoft-danger/version.rb
+++ b/lib/netsoft-danger/version.rb
@@ -1,3 +1,3 @@
 module NetsoftDanger
-  VERSION = '0.1.6'.freeze
+  VERSION = '0.1.7'.freeze
 end


### PR DESCRIPTION
thus.. a line like 
```ruby
allow(subject).to receive(:puts) # danger ok
```
will not be triggered as a fail in danger