### PR TITLE
exit with a 1 status if the sub-shell fails

### DIFF
--- a/bin/netsoft-circle
+++ b/bin/netsoft-circle
@@ -29,6 +29,7 @@ EOF
     end
 
     system('git config --global url."https://git.heroku.com/".insteadOf heroku:')
+    exit(1) unless $?.success?
   end
 
   desc 'merge', 'Merges several simplecov json result files'
@@ -63,6 +64,11 @@ EOF
         --format progress \
         $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
     EOF
+    exit(1) unless $?.success?
+  end
+
+  def self.exit_on_failure?
+    true
   end
 end
 

--- a/lib/netsoft-danger/version.rb
+++ b/lib/netsoft-danger/version.rb
@@ -1,3 +1,3 @@
 module NetsoftDanger
-  VERSION = '0.2.6'.freeze
+  VERSION = '0.2.7'.freeze
 end


### PR DESCRIPTION
fixes issue where if rspec fails, the circle job still succeeds