### PR TITLE
change the rspec junit.xml output path so it has the circle node in the filename

### DIFF
--- a/bin/netsoft-circle
+++ b/bin/netsoft-circle
@@ -58,7 +58,7 @@ EOF
       bundle _${BUNDLE_VERSION}_ exec rspec \
         --color \
         --format RspecJunitFormatter \
-        --out $CIRCLE_TEST_REPORTS/rspec/junit.xml \
+        --out $CIRCLE_TEST_REPORTS/rspec/junit-$CIRCLE_NODE_INDEX.xml \
         --format html \
         --out $CIRCLE_ARTIFACTS/rspec.html \
         --format progress \


### PR DESCRIPTION
Hoping this will fix the test balancing on Circle 2.0 builds of HS Server