### PR TITLE
support creating rspec test result links for a broader set of names

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -76,7 +76,7 @@ if ENV['CIRCLE_VERSION'] == '2.0'
 
   jest = artifacts.find{ |artifact| artifact.end_with?('jest/index.html') }
   coverage = artifacts.find{ |artifact| artifact.end_with?('coverage/index.html') }
-  rspec_files = artifacts.select{ |artifact| artifact =~ /rspec-(\d+)\.html$/ }
+  rspec_files = artifacts.select{ |artifact| artifact =~ /rspec-(.+)\.html$/ }
   teaspoon = artifacts.find{ |artifact| artifact.end_with?('teaspoon.html') }
 
   {}.tap do |hash|
@@ -89,7 +89,17 @@ if ENV['CIRCLE_VERSION'] == '2.0'
     if links.size == 1
       message("[#{msg}](#{links[0]})")
     else
-      message("#{msg} - #{links.map{|l| "[link](#{l})"}.join(', ')}")
+      r         = /rspec-(.+)\.html$/
+      the_links = links.map do |l|
+        m = r.match(l)
+        if m
+          "[#{m[1]}](#{l})"
+        else
+          "[link](#{l})"
+        end
+      end.join(', ')
+
+      message("#{msg} - #{the_links}")
     end
   end
 else

--- a/lib/netsoft-danger/version.rb
+++ b/lib/netsoft-danger/version.rb
@@ -1,3 +1,3 @@
 module NetsoftDanger
-  VERSION = '0.2.8'.freeze
+  VERSION = '0.2.9'.freeze
 end


### PR DESCRIPTION
this allows to have rspec files named  rspec-rails-4.2.html  instead of only rails-0.html