### PR TITLE
Run rubocop without bundler

### DIFF
--- a/bin/netsoft-circle
+++ b/bin/netsoft-circle
@@ -70,7 +70,8 @@ EOF
   desc 'rubocop', 'Run rubocop'
   def rubocop
     system <<-EOF
-      bundle _${BUNDLE_VERSION}_ exec rubocop \
+      rubocop \
+        --parallel \
         --format progress \
         --format html \
         --out $CIRCLE_ARTIFACTS/rubocop/report.html

--- a/lib/netsoft-danger/version.rb
+++ b/lib/netsoft-danger/version.rb
@@ -1,3 +1,3 @@
 module NetsoftDanger
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.3'.freeze
 end

--- a/rubocop/config-2019-08-12.yml
+++ b/rubocop/config-2019-08-12.yml
@@ -16,6 +16,7 @@ AllCops:
     - 'public/**/*'
     - 'tmp/**/*'
     - 'spec/dummy/**/*'
+    - 'vendor/**/*'
 
 Naming/RescuedExceptionsVariableName:
   PreferredName: ex
@@ -89,3 +90,6 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
+
+Metrics:
+  Enabled: false


### PR DESCRIPTION
Rubocop should be run without `bundle _${BUNDLE_VERSION}_ exec`, since rubocop is installed as a part of the `netsoft-danger` gem.

And `netsoft-danger` is not included in Gemfile, but installed separately on CI, which leads to `Gem::Exception` when rubocop is run with "bundle exec".

Error message: `rubocop is not currently included in the bundle`.