### PR TITLE
[circleci] deploy to rubygems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,9 @@ jobs:
           name: Deploy to gem server
           command: |-
             ./bin/tag_check.sh
+            ./bin/setup-rubygems.sh
             rm -rf pkg
             gem install geminabox
             rake build
             gem inabox -g ${HUBSTAFF_GEM_SERVER} pkg/*
+            gem push pkg/*.gem

--- a/bin/setup-rubygems.sh
+++ b/bin/setup-rubygems.sh
@@ -1,0 +1,3 @@
+mkdir ~/.gem
+echo -e "---\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
+chmod 0600 ~/.gem/credentials


### PR DESCRIPTION
This is mimicking what was done in the netsoft-rubocop gem to handle deploys