### PR TITLE
fix issue with newer faraday gem version and octokit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Next]
+### Added
+### Changed
+### Fixed
+
+## [0.3.5]
+### Added
+- package.json checks
+### Fixed
+- requie older version of faraday until octokit is fixed (https://github.com/octokit/octokit.rb/pull/1154)
+

--- a/lib/netsoft-danger/version.rb
+++ b/lib/netsoft-danger/version.rb
@@ -1,3 +1,3 @@
 module NetsoftDanger
-  VERSION = '0.3.4'.freeze
+  VERSION = '0.3.5'.freeze
 end

--- a/netsoft-danger.gemspec
+++ b/netsoft-danger.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_runtime_dependency 'danger', '~> 5.0'
   s.add_runtime_dependency 'thor'
+  s.add_runtime_dependency 'faraday', '~> 0.15.0'
 end


### PR DESCRIPTION
Fixes missing constant error as faraday 0.16.0 removed the Faraday::Error::* aliases that octokit was using.. ( https://github.com/octokit/octokit.rb/pull/1154 )